### PR TITLE
Update coreTeam.css

### DIFF
--- a/public/css/coreTeam.css
+++ b/public/css/coreTeam.css
@@ -13,6 +13,10 @@
     background-color: #ffffff;
 }
 
+#coreTeam .cardArea .ImgBox img {
+    height: 70%;
+}
+
 #leadTeam {
     height: 17%;
     width: 100%;


### PR DESCRIPTION
fixed: the height and width of images of the coreMembers page

fixed overlapping of images and text div